### PR TITLE
Rewrite API docs + scraper for the mobile dietly API

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,54 +1,80 @@
-# dietly.pl reverse-engineered API
+# dietly.pl mobile API — reverse-engineered
 
-Notes from analysing `dietly.pl.har` (51 entries, captured on a company page in
-Wrocław). Everything here is either directly observed in the HAR or marked
-"inferred" where I had to extrapolate.
+Notes from analysing `HTTPToolkit_2026-04-26_21-20.har` (232 entries, captured
+from the **Android app** browsing Wrocław, companies `robinfood` and
+`mangodiet`). Everything here is directly observed in the HAR; "inferred" tags
+mark the few places I had to extrapolate.
+
+The previous capture (commit `9420f3e`) covered the **website** at
+`https://dietly.pl/api/dietly/open/...`. This one covers the mobile app at
+`https://aplikacja.dietly.pl/api/mobile/open/...`. The mobile endpoints return
+slightly richer data (tier descriptions, human-readable delivery info) and
+expose a few endpoints the web app doesn't (notably `/menu/...` with full
+nutrition + ingredients per dish, and `/awarded-and-top` with the entire
+city catalog). Prefer mobile.
 
 ## Hosts & auth
 
-- Base host: `https://dietly.pl`
-- Anonymous browsing only requires a session cookie set by the Next.js app
-  (no API key, no JWT). The `/api/dietly/open/...` and `/api/open/...` paths
-  are explicitly public — they return data without any auth header.
-- `/api/profile/*` paths require the user's session cookie (logged-in user) and
-  are not relevant for scraping public diet/price catalogs.
-- Useful request headers (the site sends them; most are not actually required,
-  but the API checks `referer` softly):
-  - `accept: application/json`
-  - `referer: https://dietly.pl/catering-dietetyczny-firma/{companyId}`
-  - `company-id: {companyId}` — sent on company-card endpoints. Probably used
-    server-side for routing/multi-tenant; the slug in the path is also
-    `{companyId}`.
-  - `accept-language: pl` works fine.
+- Base host: `https://aplikacja.dietly.pl`
+- All `/api/mobile/open/...` and `/api/open/...` endpoints are **anonymous** —
+  no cookies, no API key, no JWT.
+- `/api/profile/...` paths require a logged-in session (observed: 401 for
+  `coupons-search` without auth). We can't use the coupons endpoint
+  programmatically; see "Promo codes" below for the workaround.
 
-## Identifiers used everywhere
+The Android app sends:
 
-| ID | Where it comes from | Example |
-|---|---|---|
-| `cityId` | `top-search` → `cities[].cityId` | `986283` (Wrocław) |
-| `companyId` | a slug; URL-stable; e.g. `robinfood` | `robinfood` |
-| `dietId` | `companyDiets[].dietId` | `4` ("Wybór menu") |
-| `tierId` | `companyDiets[].dietTiers[].tierId` | `6` ("Pakiet Comfort") |
-| `dietOptionId` | `dietTiers[].dietOptions[].dietOptionId` | `15` ("Standard Food") |
-| `tierDietOptionId` | `"{tierId}-{dietOptionId}"` | `"6-15"` |
-| `dietCaloriesId` | leaf node — picks a specific kcal level | `65` (1200 kcal Standard Food) |
+```
+content-type: application/json
+accept-language: pl-PL
+x-launcher-type: ANDROID_APP
+x-mobile-version: 4.0.0
+company-id: {companyId}        # only on company-card endpoints; URL already has it, header is redundant
+user-agent: okhttp/4.9.2
+```
 
-The hierarchy is: **company → diet → tier → dietOption → dietCalories**. The
-`dietCaloriesId` is the only thing the price endpoint actually needs (plus
-optional `tierDietOptionId` if the diet supports menu configuration).
+In practice the API enforces `accept-language` (Polish content), `content-type`
+on POSTs, and — verified by live testing — the **`company-id` header is required**
+for every `/api/mobile/open/company-card/{companyId}/...` request. Without it
+the server returns 400, even though the same companyId is in the URL path.
+`x-launcher-type` and `x-mobile-version` are safe to forge.
+
+No rate-limit headers were observed. Be polite: 1–2 req/s per company.
+
+## Identifiers
+
+Hierarchy: **company → diet → tier → dietOption → dietCalories** (leaf).
+
+| ID | Where it comes from | Example | Notes |
+|---|---|---|---|
+| `cityId` | `top-search` → `cities[].cityId`, also `cities/top-10` | `986283` (Wrocław) | `int` |
+| `companyId` | URL slug; `awarded-and-top` returns `name` (= slug) | `robinfood`, `mangodiet` | `string`, URL-stable |
+| `dietId` | `companyDiets[].dietId` | `4` ("Wybór menu"), `9` ("Standard Food") | `int` |
+| `tierId` | `dietTiers[].tierId` | `6` ("Pakiet Comfort") | `int`. Only set for menu-config diets. |
+| `dietOptionId` | `dietOptions[].dietOptionId` | `15` ("Standard Food") | `int` |
+| `tierDietOptionId` | composite `"{tierId}-{dietOptionId}"` | `"6-15"` | `string`. Required by `quick-order/calculate-price` for menu-config diets, omitted for fixed diets. |
+| `dietCaloriesId` | `dietCalories[].dietCaloriesId` (leaf) | `65` (1200 kcal Standard) | `int`. **The only ID strictly needed for pricing and menu queries.** |
+| `dietCaloriesMealId` | `meals[].options[].dietCaloriesMealId` | `358` | `int`. The per-day, per-kcal, per-dish ID — use this to track menus over time. |
+
+Two diet shapes coexist within the same company:
+
+- **Menu-config diet** (e.g. `dietId=4`, "Wybór menu"): `dietTiers` is non-empty
+  and contains `dietOptions` per tier; the diet's top-level `dietOptions` is
+  empty. Pricing requires `tierDietOptionId`.
+- **Fixed/ready diet** (e.g. `dietId=9`, "Standard Food"): `dietTiers` is empty
+  and `dietOptions` lives at the diet level. No `tierDietOptionId` needed.
+
+`isMenuConfiguration` and `dietTag == "MENU_CONFIGURATION"` flag the first
+shape.
 
 ---
 
 ## 1. Discovery
 
-### `GET /api/open/search/top-search`
+### `GET /api/open/search/top-search?query={name}&citiesSize={n}&companiesSize={n}&cityId=`
 
-Query params:
-- `query` (string, URL-encoded; e.g. `Wroc%C5%82aw`)
-- `citiesSize` (int) — max cities to return
-- `companiesSize` (int) — max companies to return
+Resolve a city name to a `cityId`. Identical shape to the web API.
 
-Response:
 ```jsonc
 {
   "cities": [
@@ -56,96 +82,175 @@ Response:
       "cityId": 986283,
       "name": "Wrocław",
       "sanitizedName": "wroclaw",
-      "countyName": "Wrocław",
-      "municipalityName": "Wrocław",
       "provinceName": "DOLNOŚLĄSKIE",
-      "cityStatus": true,             // true = a city the platform supports
-      "numberOfCompanies": 156,        // cateringa active in this city
-      "largestCityForName": false
+      "cityStatus": true,
+      "numberOfCompanies": 156
     }
   ],
-  "companies": [],                     // populated when companiesSize > 0
+  "companies": [],            // populated if companiesSize > 0 — not exercised in HAR
   "diets": [],
   "moreCitiesAvailable": false,
-  "moreCompaniesAvailable": false,
-  "moreDietsAvailable": false
+  ...
 }
 ```
 
-This is the canonical way to look up a `cityId` from a name.
+### `GET /api/mobile/open/cities/top-10`
 
-### Listing all companies in a city — *not in HAR, inferred*
+Top-10 cities with delivery-window info. Useful as a seed list.
 
-The Next.js page at `https://dietly.pl/catering-dietetyczny/{citySlug}` (e.g.
-`/catering-dietetyczny/wroclaw`) lists every catering with prices. Two ways to
-get its data without parsing HTML:
+```jsonc
+[
+  {
+    "cityId": 918123,
+    "name": "Warszawa",
+    "sanitizedName": "warszawa",
+    "sectorId": 86,
+    "deliveryFee": null,
+    "deliveryTime": [
+      { "deliveryTimeId": 229, "timeFrom": "23:59:59", "timeTo": "08:00:00" }
+    ]
+  }
+]
+```
 
-1. **Next.js page-data JSON.** The HAR shows the analogous request for the
-   single-company page:
-   `GET /_next/data/{buildId}/catering-dietetyczny-firma/{companyId}.json?companyId={companyId}`
-   The buildId (`jekAjoBrwS6rgioh0IGjO` in this HAR) rotates on every deploy —
-   parse it from any HTML page (`<script id="__NEXT_DATA__">.buildId`). The
-   listing equivalent would be
-   `/_next/data/{buildId}/catering-dietetyczny/{citySlug}.json`.
-2. **Use `top-search`** with `companiesSize=200&query={cityName}` — the HAR
-   only shows `companiesSize=0`, but the `companies` field exists in the
-   response shape.
+`timeFrom: "23:59:59"` is the API's "open-ended / overnight" sentinel.
 
-If a stable, no-HTML path matters, option 2 is preferable because it doesn't
-depend on the rotating buildId.
+### `GET /api/dietly-shop/open/supported-cities`
 
----
+Full list of supported cities for the Dietly Shop product. Not exercised in
+HAR but listed here for completeness.
 
-## 2. Company-card endpoints
+### `GET /api/open/search/full/awarded-and-top?cId={cityId}&page={n}&pageSize={n}&rV=V2023_1&active=`
 
-All of these are scoped to one `(companyId, cityId)` pair.
-
-### `GET /api/dietly/open/company-card/{companyId}/constant?cityId={cityId}`
-
-The big one — returns the full catalog of diets, tiers, options, and the kcal
-matrix for a company in a given city. Response top-level keys:
+**The catalog endpoint.** Lists every company that delivers to a city, with
+ratings, params, and any active promotion. For Wrocław the HAR shows
+`totalElements=152` over 16 pages of 10. Use `rV=V2023_1` — it returns more
+fields than the legacy variant.
 
 ```jsonc
 {
-  "companyDiets": [...],     // diets/tiers/options tree (see below)
-  "companyHeader": {...},    // name, logo, ratings, active promo banner
-  "companyParams": {...},    // booleans (deliveryOnSaturday, etc.)
-  "companySideOrders": [...],
-  "contactDetails": {...},
-  "deliveryCities": [...],   // other cities the catering delivers to
-  "formSettings": {...},
-  "images": [...],
-  "menuSettings": { "menuEnabled": true, "menuDaysAhead": 18 },
-  "programs": [...]          // marketing copy
+  "city": { ... },
+  "currentPage": 0,
+  "totalPages": 16,
+  "totalElements": 152,
+  "histogramResponses": { ... },        // rating distribution
+  "searchData": [
+    {
+      "name": "robinfood",                // <- companyId slug
+      "fullName": "Robin Food",
+      "rate": 4.76,
+      "numberOfRates": 298,
+      "awarded": true,
+      "priceCategory": "CHEAP",          // CHEAP / AVERAGE / EXPENSIVE
+      "dietNames": ["dieta Standard Food", ...],
+      "numberOfDiets": 8,
+      "inviteCodeDiscountPercent": 20.0, // referral discount
+      "shortDescription": "...",
+      "params": {
+        "deliveryOnSaturday": true,
+        "deliveryOnSunday": true,
+        "selfPickup": false,
+        "loyaltyProgramEnabled": true,
+        "menuSelectionEnabled": true,
+        "hasDietWithMenuConfiguration": true,
+        "hasActivePromotions": true,
+        ...
+      },
+      "activePromotionInfo": {
+        "promoText": "Promocja -30%  KOD:ROBIM30",
+        "promoDeadline": "2026-04-26",
+        "code": "ROBIM30",
+        "discountPercents": 30
+      },
+      "galleryImages": [ ... ],
+      "orderPossibleOn": "2026-04-29",
+      "orderPossibleTo": "2026-04-27T06:00:00"
+    }
+  ]
 }
 ```
 
-Per-diet shape (`companyDiets[i]`):
+`searchData[].name` is the `companyId` slug — feed it into `/company-card/...`
+endpoints.
+
+### `GET /api/open/search/saved-meal-offers/count?cityId={cityId}`
+
+Returns an integer count of "Paczki Niespodzianki" offers in a city. Not
+useful for catalog scraping.
+
+---
+
+## 2. Company catalog
+
+All scoped to a `(companyId, cityId)` pair. The `company-id` request header
+must match the slug in the URL — it's a hard requirement, not a hint.
+
+### `GET /api/mobile/open/company-card/{companyId}/constant?cityId={cityId}`
+
+Full diet/tier/option/kcal tree plus header, contact, gallery, side-orders.
+
+Top-level keys:
+
+```jsonc
+{
+  "companyHeader":   { ... },   // name, logos, ratings, activePromotionInfo, deliveryInfo
+  "companyParams":   { ... },   // bool flags (deliveryOnSaturday, loyaltyProgramEnabled, ...)
+  "companyDiets":    [ ... ],   // diet/tier/option tree (see below)
+  "companySideOrders": [ ... ],
+  "contactDetails":  { ... },
+  "deliveryCities":  [ ... ],
+  "formSettings":    { ... },
+  "images":          [ ... ],
+  "menuSettings":    { "menuEnabled": true, "menuDaysAhead": 18 },
+  "programs":        [ ... ]
+}
+```
+
+`companyHeader` (note: when there's no active promo, all `activePromotionInfo`
+fields are `null`/`false`; otherwise `code` is the promo code):
+
+```jsonc
+{
+  "name": "mango.diet",
+  "logoUrl": "https://ml-assets.com/...",
+  "rateValue": 92.0,                  // 0–100
+  "feedbackValue": 4.82,              // 0–5
+  "feedbackNumber": 369,
+  "activePromotionInfo": {
+    "promoText": "Promocja -30%  KOD:MG30",
+    "promoDeadline": "2026-05-03",
+    "code": "MG30",
+    "discountPercents": 30,
+    "separate": true                  // true = code not auto-applied to advertised price
+  },
+  "deliveryInfo": { "date": "2026-04-28", "text": "Zamów do 05:00 (jutro) - dostawa we wtorek" },
+  "rate": 4.82,
+  "dietlyDelivery": true              // delivered by Dietly's logistics, not the catering
+}
+```
+
+Per-diet, menu-config shape:
+
 ```jsonc
 {
   "dietId": 4,
   "name": "Wybór menu",
-  "description": "...",
-  "imageUrl": "https://ml-assets.com/.../robinfood-4-88bf.jpg",
-  "awarded": false,
+  "dietTag": "MENU_CONFIGURATION",
+  "isMenuConfiguration": true,
+  "imageUrl": "https://ml-assets.com/images/diets/robinfood/robinfood-4-88bf.jpg",
   "avgScore": 94.0,
   "feedbackValue": 4.74,
   "feedbackNumber": 277,
-  "dietTag": "MENU_CONFIGURATION",      // see /api/open/diet-tag-info/all
-  "isMenuConfiguration": true,           // true → user picks meals; uses tiers
   "dietMealCount": 40,
-  "discounts": [
-    { "discount": 5.0,  "minimumDays": 5,  "discountType": "PERCENTAGE" },
-    { "discount": 10.0, "minimumDays": 10, "discountType": "PERCENTAGE" }
-  ],
+  "dietOptions": [],                  // empty for menu-config; lives under tiers
   "dietTiers": [
     {
       "tierId": 6,
       "name": "Pakiet Comfort",
-      "minPrice": "67.00 zł",            // string, not numeric
+      "description": "25 posiłków do wyboru codziennie",
+      "minPrice": "67.00 zł",         // string with currency!
       "mealsNumber": 25,
-      "defaultOptionChange": true,
-      "tag": null,                        // or "BESTSELLER", "VEGE", etc.
+      "tag": null,                    // "BESTSELLER", "VEGE", etc.
       "dietOptions": [
         {
           "dietOptionId": 15,
@@ -153,91 +258,146 @@ Per-diet shape (`companyDiets[i]`):
           "name": "Standard Food",
           "dietOptionTag": "STANDARD",
           "dietCalories": [
-            { "dietCaloriesId": 65, "calories": 1200 },
-            { "dietCaloriesId": 66, "calories": 1500 },
-            { "dietCaloriesId": 67, "calories": 1800 },
-            { "dietCaloriesId": 68, "calories": 2000 },
+            { "dietCaloriesId": 65,  "calories": 1200 },
+            { "dietCaloriesId": 66,  "calories": 1500 },
+            { "dietCaloriesId": 67,  "calories": 1800 },
+            { "dietCaloriesId": 68,  "calories": 2000 },
             { "dietCaloriesId": 184, "calories": 2200 },
-            { "dietCaloriesId": 69, "calories": 2500 },
-            { "dietCaloriesId": 70, "calories": 3000 }
+            { "dietCaloriesId": 69,  "calories": 2500 },
+            { "dietCaloriesId": 70,  "calories": 3000 }
           ],
           "defaultOption": true
         }
+      ]
+    }
+  ],
+  "discounts": [
+    { "discount": 5.0,  "minimumDays": 5,  "discountType": "PERCENTAGE" },
+    { "discount": 10.0, "minimumDays": 10, "discountType": "PERCENTAGE" }
+  ]
+}
+```
+
+Per-diet, fixed shape (`dietId=9`, "Standard Food"):
+
+```jsonc
+{
+  "dietId": 9,
+  "name": "dieta Standard Food",
+  "dietTag": "STANDARD",
+  "isMenuConfiguration": false,
+  "dietTiers": [],
+  "dietOptions": [
+    {
+      "dietOptionId": 27,
+      "name": "Standard Food",
+      "dietOptionTag": "STANDARD",
+      "dietCalories": [
+        { "dietCaloriesId": 140, "calories": 1200 },
+        { "dietCaloriesId": 141, "calories": 1500 },
+        ...
       ]
     }
   ]
 }
 ```
 
-For "ready" (non-configurable) diets, `dietTiers` is empty and the diet itself
-has its kcal matrix collapsed into a single price tier — the *price* endpoint
-below is what you need then.
+Robinfood/Wrocław has 8 diets: `Wybór menu` (4) and seven fixed diets (9, 7,
+10, 8, 12, 11, 13) tagged `STANDARD / DASH / LOW IG / GLUTEN LACTOSE FREE /
+LOW CARB / SPORT / HOME`.
 
-### `GET /api/dietly/open/company-card/{companyId}/city/{cityId}`
+### `GET /api/mobile/open/company-card/{companyId}/city/{cityId}`
 
-Lightweight. Returns headline pricing and city info — useful when you only need
-"what's the cheapest plan?" without all the diet tree:
+Lightweight pricing snapshot.
 
 ```jsonc
 {
   "dietPriceInfo": [
     {
-      "dietId": 4,
-      "discountPrice": "62.00 zł",
-      "defaultPrice": "62.00 zł",
-      "dietCaloriesIds": [147, 148, ...],   // every kcal node available for this diet
-      "dietPriceInCompanyPromotion": false
+      "dietId": 16,
+      "discountPrice": "73.50 zł",       // post-promo headline
+      "defaultPrice": "105.00 zł",       // pre-promo
+      "dietCaloriesIds": [103, 104, 105], // every kcal node for this diet
+      "dietPriceInCompanyPromotion": true
     }
   ],
   "companySettings": { "ordersEnabled": true, "deliveryEnabled": true },
-  "companyPriceCategory": "CHEAP",            // CHEAP / MEDIUM / EXPENSIVE
+  "companyPriceCategory": "AVERAGE",     // CHEAP / AVERAGE / EXPENSIVE
   "awarded": true,
   "citySearchResult": {
-    "cityId": 986283, "name": "Wrocław", "deliveryFee": null, ...
+    "cityId": 986283,
+    "name": "Wrocław",
+    "sectorId": 66,
+    "deliveryFee": null,
+    "deliveryTime": [
+      { "deliveryTimeId": 107, "timeFrom": "23:59:59", "timeTo": "06:00:00" }
+    ]
   },
   "lowestPrice": {
-    "standard": "57.00 zł",                   // cheapest "ready" diet
-    "menuConfiguration": "62.00 zł"           // cheapest configurable diet
+    "standard": "54.60 zł",              // cheapest fixed diet
+    "menuConfiguration": "60.90 zł"      // cheapest menu-config diet
   }
 }
 ```
 
-The `defaultPrice`/`discountPrice` here are **per-day** prices and they are
-the *advertised* baseline. They do not reflect order-length discounts.
+Note: `discountPrice/defaultPrice` are **advertised** rates and ignore order
+length. For the truthful number use `quick-order/calculate-price`.
 
-### `POST /api/dietly/open/company-card/{companyId}/quick-order/calculate-price`
+### `GET /api/mobile/open/company-card/{companyId}/feedback?sort=DATE&page={n}&pageSize={n}`
 
-This is the truthful price oracle. Use it when comparing — it applies
-order-length discounts, promo codes, etc.
+Reviews. `aggregation` has score histograms; `results[]` has per-review fields
+including six dimensional scores (`scoreTaste`, `scoreAesthetics`,
+`scoreIngredientsQuality`, `scorePackaging`, `scoreVariety`, `scoreDelivery`),
+`orderDuration`, `lastDeliveryDate`, `verified`, optional `responseText`.
 
-Body:
+---
+
+## 3. Pricing — the only truthful numbers
+
+### `POST /api/mobile/open/company-card/{companyId}/quick-order/calculate-price`
+
+Apples-to-apples per-day price. Use this for cross-company comparison.
+
+Body (menu-config diet — `tierDietOptionId` required):
+
 ```json
 {
-  "promoCodes": [],
-  "deliveryDates": ["2026-04-29", "2026-04-30", "..."],
-  "dietCaloriesId": 77,
-  "testOrder": false,
   "cityId": 986283,
-  "tierDietOptionId": "6-15"
+  "deliveryDates": ["2026-04-26"],
+  "dietCaloriesId": 65,
+  "tierDietOptionId": "6-15",
+  "promoCodes": [""],
+  "testOrder": false
 }
 ```
 
-- `deliveryDates` is the list of *individual delivery days*. Length of this
-  array is what triggers the "longer order = bigger discount" tiers.
-- `tierDietOptionId` is **omitted** for non-tiered (ready) diets — only sent
-  for `isMenuConfiguration: true` diets.
-- `promoCodes`: e.g. `["ROBIM30"]`.
+Body (fixed diet — omit `tierDietOptionId`):
 
-Response:
+```json
+{
+  "cityId": 986283,
+  "deliveryDates": ["2026-04-26"],
+  "dietCaloriesId": 140,
+  "promoCodes": [""]
+}
+```
+
+`deliveryDates` is a list of individual days. **Order-length discount is
+applied based on the array length** — pass 5 days for 5%, 10 days for 10%, etc.
+Empty strings in `promoCodes` are tolerated.
+
+Response (no promo):
+
 ```jsonc
 {
   "cart": {
-    "totalCostToPay": 603.00,
-    "totalCostWithoutDiscounts": 670.00,
-    "totalLowest30DaysCostWithoutDiscounts": 680.00,   // for "Omnibus" disclosure
+    "totalCostToPay": 67.00,                       // float, PLN, post-discounts
+    "totalCostWithoutDiscounts": 67.00,
+    "totalLowest30DaysCostWithoutDiscounts": null,  // Omnibus disclosure, set when promo applied
     "totalDeliveryCost": 0.00,
     "totalPromoCodeDiscount": 0,
-    "totalOrderLengthDiscount": 67.00,
+    "totalPromoCodeDiscountInfo": "",
+    "totalOrderLengthDiscount": 0.00,
     "totalDeliveriesOnDateDiscount": 0.00,
     "totalLoyaltyPointsDiscount": 0.00,
     "totalPickupPointDiscount": 0.00,
@@ -248,132 +408,353 @@ Response:
   "items": [
     {
       "itemId": "company-visiting-card-quick-order",
-      "perDayDietCost": 67.00,                  // pre-discount per-day
-      "perDayDietWithDiscountsCost": 60.30,     // post-discount per-day
-      "totalDietWithDiscountsAndSideOrdersCost": 603.00,
-      "totalDietWithSideOrdersCost": 670.00,
-      "totalDietWithoutSideOrdersCost": 670.00,
-      "totalSideOrdersCost": 0.00
+      "perDayDietCost": 67.00,
+      "perDayDietWithDiscountsCost": 67.00,
+      "totalDietWithDiscountsAndSideOrdersCost": 67.00,
+      "totalDietWithSideOrdersCost": 67.00,
+      "totalDietWithoutSideOrdersCost": 67.00,
+      "totalSideOrdersCost": 0.00,
+      "totalCutleryCost": 0.00,
+      "totalSideOrdersWithoutCutleryCost": 0.00,
+      "totalMealsChosenCost": 0
     }
   ]
 }
 ```
 
-### `GET /api/dietly/open/company-card/{companyId}/menu/{dietCaloriesId}/city/{cityId}/date/{YYYY-MM-DD}?tierId={tierId}`
+Response (mango.diet, 1 day, `promoCodes: ["MG30"]`):
 
-Day-level menu — the actual meals. `tierId` is optional (only for menu-
-configuration diets). Only useful if you want food details, not pricing.
-
-Response shape:
 ```jsonc
 {
-  "date": "2026-04-29",
+  "cart": {
+    "totalCostToPay": 61.60,
+    "totalCostWithoutDiscounts": 88.00,
+    "totalLowest30DaysCostWithoutDiscounts": 85.00,   // Omnibus reference price
+    "totalPromoCodeDiscount": 26.40,
+    "totalPromoCodeDiscountInfo": "",
+    ...
+  },
+  ...
+}
+```
+
+The `MG30` example is concrete proof the API accepts public promo codes for
+anonymous quotes — we use this to validate codes scraped from banners.
+
+### `POST /api/mobile/open/shopping-cart/calculate-price`
+
+Full cart with hand-picked meals, side orders, loyalty points, multi-order.
+
+Body:
+
+```json
+{
+  "cityId": 986283,
+  "companyId": "robinfood",
+  "promoCodes": [],
+  "loyaltyProgramPoints": 0,
+  "loyaltyProgramPointsGlobal": 0,
+  "simpleOrders": [
+    {
+      "itemId": "Ll5v-YFDomCtdwOP4KyRQ",      // client-generated, opaque
+      "deliveryDates": ["2026-04-29", "2026-04-30", "..."],
+      "customDeliveryMeals": {},                // per-date overrides; empty = same meals every day
+      "deliveryMeals": [
+        { "amount": 1, "dietCaloriesMealId": 676 },
+        { "amount": 1, "dietCaloriesMealId": 680 },
+        { "amount": 1, "dietCaloriesMealId": 692 },
+        { "amount": 1, "dietCaloriesMealId": 699 },
+        { "amount": 1, "dietCaloriesMealId": 701 }
+      ],
+      "dietCaloriesId": 145,
+      "paymentType": "ONLINE",
+      "pickupPointId": null,
+      "sideOrders": [],
+      "testOrder": false
+    }
+  ]
+}
+```
+
+Response shape is the same `{ cart, items }`. Loyalty points awarded scale
+with the order (5 meals × 1 day = 50 points; 5 meals × 10 days = 750 points).
+
+`deliveryDates: []` is valid and treats the order as a 1-day quote.
+
+---
+
+## 4. Menus — what we want to track over time
+
+### `GET /api/mobile/open/company-card/{companyId}/menu/{dietCaloriesId}/city/{cityId}/date/{YYYY-MM-DD}`
+
+Optional query: `?tierId={tierId}` (only for menu-config diets).
+
+```jsonc
+{
+  "date": "2026-04-26",
   "calories": 1200,
   "meals": [
     {
-      "name": "Śniadanie",
-      "baseDietCaloriesMealId": 298,
+      "name": "Śniadanie",                        // Polish meal-type label
+      "baseDietCaloriesMealId": 298,              // default option for this slot
       "options": [
         {
           "dietCaloriesMealId": 358,
-          "name": "...",
-          "label": "Fit Food",
-          "info": "295 kcal • B:14g • W:19g • T:17g",
-          "thermo": "COLD",
-          "reviewsNumber": 781,
-          "reviewsScore": 90.65,
+          "name": "Pasta twarogowa z szynką z chlebem żytnim ze słonecznikiem i papryką",
+          "label": "Fit Food",                    // dietOption variant label
+          "info": "300 kcal • B:19g • W:30g • T:11g",   // B=Białka(prot), W=Węglowodany(carbs), T=Tłuszcze(fat)
+          "thermo": "COLD",                       // COLD / WARM / COLD_WARM
+          "reviewsNumber": 46,
+          "reviewsScore": 97.83,
           "details": {
             "name": "...",
-            "allergens": "Mleko, gluten, ...",
-            "allergensWithExcluded": [...],
-            "ingredients": [...]
+            "imageUrl": "https://ml-assets.com/images/diets/robinfood/robinfood-706069CLIENT-6286.jpg",
+            "calories": "300.45 kcal / 1257 kJ",
+            "protein": "18.87g",
+            "carbohydrate": "30.46g",
+            "fat": "11.46g",
+            "saturatedFattyAcids": "1.22g",
+            "sugar": "4.27g",
+            "salt": "2.26g",
+            "dietaryFiber": "3.08g",
+            "thermo": "COLD",
+            "allergens": "Mleko, Zboża zawierające gluten, ...",   // pretty string
+            "allergensWithExcluded": [
+              {
+                "dietaryExclusionId": 1,
+                "companyAllergenName": "Zboża zawierające gluten, tj. pszenica, ...",
+                "dietlyAllergenName": "gluten",                       // <- normalized, use this
+                "excluded": false
+              }
+            ],
+            "ingredients": [
+              { "name": "Twaróg sernikowy (twaróg(MLEKO))", "major": false, "exclusion": [] }
+            ]
           }
         }
       ]
-    }
+    },
+    { "name": "II Śniadanie",  "baseDietCaloriesMealId": ..., "options": [...] },
+    { "name": "Obiad",         "baseDietCaloriesMealId": ..., "options": [...] },
+    { "name": "Podwieczorek",  "baseDietCaloriesMealId": ..., "options": [...] },
+    { "name": "Kolacja",       "baseDietCaloriesMealId": ..., "options": [...] }
   ]
 }
 ```
 
-Allowed dates run `today + 1` up to `today + menuSettings.menuDaysAhead`
-(18 in this HAR). Note the URL takes `dietCaloriesId` (the leaf, kcal-specific
-ID), **not** `dietId`.
+Robinfood serves 5 meal-types × 5 options each per day for `dietCaloriesId=65`
+(1200 kcal, Standard). Mango Wrocław serves 5 meal-types × 6 options each.
 
-### `GET /api/dietly/open/company-card/{companyId}/feedback?pageSize=10&sort=DATE`
+For tracking changes day-over-day or week-over-week, the stable identifier is
+`dietCaloriesMealId`. The same dish will keep its ID; what changes is which
+IDs appear on which day. Macros and ingredients are stable per-ID.
 
-Reviews. Optional `page` query param (0-indexed). Response:
+`menuSettings.menuDaysAhead` (from `/constant`) bounds how many days into the
+future you can query — 18 days for the cateringa observed. Past dates 404.
+
+This endpoint is the slowest (~400 ms) because of the nutrition + ingredients
+payload. Throttle accordingly.
+
+---
+
+## 5. Promo codes & promotions
+
+There is no anonymous "list all coupons" endpoint — `/api/profile/coupons-search`
+returns 401 without login. Promo codes are surfaced through several feeds:
+
+### `companyHeader.activePromotionInfo` (in `/constant`)
+
+The cleanest source. Per-company, per-city. Fields: `code`, `discountPercents`,
+`promoDeadline` (`YYYY-MM-DD`), `promoText`, `separate`. `null` everywhere
+when there's no active promo.
+
+### `searchData[].activePromotionInfo` (in `/awarded-and-top`)
+
+Same shape. Lets you discover every company's promo in a city in one paginated
+sweep without fetching `/constant` per company.
+
+### `GET /api/open/mobile/banners?cId={cityId}`
+
+City-scoped marketing banners. Each banner has:
+
 ```jsonc
 {
-  "results": [{ "feedbackId": "...", "userName": "...", "dietId": 4, "avgScore": 5.0, "text": "...", ... }],
-  "pageNumber": 0,
-  "totalPages": 31,
-  "aggregation": {
-    "avgTaste": 4.7, "avgScore": 4.76, "count": 298, ...
+  "name": "ROBIM30",
+  "code": "ROBIM30",                                  // promo code string (or campaign name)
+  "url": "https://ml-assets.com/images/...",          // banner image
+  "validFrom": "2026-04-13T09:30:00+02:00",
+  "validTo":   "2026-04-26T23:59:00+02:00",
+  "deepLink": "dietly://mobile/catering-dietetyczny-firma/robinfood",
+  "target": "DASHBOARD",                              // DASHBOARD / SAVED_MEALS / COMPANIES
+  "priority": 1,                                       // lower = shown first
+  "type": "CAMPAIGN"                                   // CAMPAIGN / STANDALONE
+}
+```
+
+`type=CAMPAIGN` banners typically carry redeemable codes. `type=STANDALONE`
+are referral / generic programme cards (`PACZKI`, `REFERRAL`).
+
+### `GET /api/open/content-management/recommended-diets?cId={cityId}&page=0&pageSize=5`
+
+Hand-curated dashboard list. Each entry has `activePromotion.code` plus
+enough company/diet IDs to drive a price quote:
+
+```jsonc
+{
+  "companyData":   { "companyId": "twojemenu", "companyName": "Twoje Menu", "awarded": false, ... },
+  "dietDetails":   { "dietId": 7, "dietName": "Twoje Menu Basic | Odchudzająca 5 posiłków",
+                     "tierId": 1, "dietOptionId": 8, "tierDietOptionId": "1-8",
+                     "menuConfiguration": true },
+  "feedbackMetrics": { "avgScore": 92, "feedbackValue": 4.88, "feedbackNumber": 1200 },
+  "pricingData":   { "minDietPrice": 67.94, "priceCategory": "CHEAP" },
+  "activePromotion": {
+    "promoText": "Promocja -25%  KOD:WIOSNA",
+    "promoDeadline": "2026-04-27",
+    "code": "WIOSNA",
+    "discountPercents": 25
   }
 }
 ```
 
----
+### Validating a discovered code
 
-## 3. Reference data
-
-### `GET /api/open/diet-tag-info/all`
-
-Big static catalog of diet *tags* (Standard, Keto, Wege, Samurai, ...) with
-human descriptions, allowed kcal levels, and image URLs. Use this to map the
-`dietTag` strings on each `companyDiet` to a presentable label.
-
-### `GET /api/dietly/open/form-settings`
-
-Per-company contact data, social URLs, descriptions, packaging info, kitchen
-address. Bulk reference data.
-
-### `GET /api/open/feature-flags`
-
-Just a list of strings: `["enable-dietly-shop", "enable-social-auth", ...]`.
-
-### `GET /api/open/campaign-settings/active-campaign`
-
-Active site-wide promotion: code, title, dates, discount %, banner image.
+Pass it through `quick-order/calculate-price`. If the code is invalid the
+`totalPromoCodeDiscount` stays `0` and the price is unchanged; if valid, you
+see the discount math (and `totalLowest30DaysCostWithoutDiscounts` populates
+with the Omnibus reference).
 
 ---
 
-## 4. Recommended workflow for diet/price comparison
+## 6. Reference / supporting
 
-1. **Resolve city.** `top-search?query={name}&citiesSize=10&companiesSize=0` →
-   pick the one with `cityStatus: true`.
-2. **List companies in that city.** Either
-   - `top-search?query={cityName}&citiesSize=0&companiesSize=200`, or
-   - fetch `/_next/data/{buildId}/catering-dietetyczny/{citySlug}.json` (need
-     to extract `buildId` from any page's `__NEXT_DATA__` first).
-3. **For each `companyId`:** fetch
-   `/api/dietly/open/company-card/{companyId}/constant?cityId={cityId}`
-   to get the full diet/tier/option tree + kcal IDs.
-4. **For each (diet, tier, option, kcal) leaf you care about:** call
-   `POST /quick-order/calculate-price` with the desired number of days. This
-   gives the apples-to-apples discounted price you'd actually pay.
-5. (Optional) Pull menu samples via the `/menu/{dietCaloriesId}/...` endpoint
-   and reviews via `/feedback`.
+### `GET /api/open/diet-tag-info?dietTagId={tag}` and `GET /api/mobile/open/diet-tag-info?dietTagId={tag}`
 
-### Picking dates for `calculate-price`
+Marketing copy for a diet tag. `tag` values observed:
+`STANDARD`, `SPORT`, `LOW IG`, `LOW CARB`, `HOME`, `GLUTEN LACTOSE FREE`,
+`DASH`. URL-encode spaces as `%20` (web variant) or `+` (mobile variant) —
+both work.
 
-Use *consecutive future weekdays* respecting the company's
-`companyParams.deliveryOnSaturday` / `deliveryOnSunday` flags. The "discount
-tier" depends on the *count* of dates, so if you want to see e.g. the 5-day,
-10-day, and 20-day prices, run the call three times with different array
-lengths.
+```jsonc
+{
+  "dietTagInfoId": 2,
+  "dietTagId": "STANDARD",
+  "name": "Standardowa",
+  "locativeName": "Standardowej",
+  "additionalName": "dieta standard",
+  "calories": [1200, 1500, 1800, 2000, 2500],         // typical kcal options
+  "main": true,
+  "priority": 1,
+  "urlName": "standardowa",
+  "imageUrl": "https://miscellaneous-images.s3.eu-central-1.amazonaws.com/dietly-diets/STANDARD.jpg",
+  "dietTagBulletPoints": ["...", "...", "..."],
+  "dietDescriptions": [ { "title": "...", "description": "..." } ]
+}
+```
+
+Other tag values appear in `companyDiets[].dietTag`: `MENU_CONFIGURATION`,
+`KETO`, `VEGE`, `VEGETARIAN`, `WEIGHT LOSS`, `LACTOSE FREE` — but they aren't
+all valid as `dietTagInfo` queries. There is no "list all tags" endpoint;
+just collect the distinct `dietTag` values seen across `/constant` responses.
+
+### `GET /api/mobile/open/possible-side-orders?withCustomDates=true`
+
+Catalogue-wide side-orders (cross-company defaults).
+
+```jsonc
+[
+  {
+    "possibleSideOrderId": 21,
+    "name": "Dodatkowy obiad w wariancie klasycznym",
+    "description": "ok. 500-600 kcal",
+    "defaultPrice": 18.9,
+    "minQuantity": 1,
+    "maxQuantity": 100,
+    "limitedByMaximumSelectedMeals": true,
+    "customDates": false,
+    "type": "DEFAULT"
+  }
+]
+```
+
+Per-company side-orders live under `companySideOrders` in the `/constant`
+response (different shape: `id.courseAsSideOrderId`, `imageUrl`, ratings).
+
+### Order-form helpers (mostly UI config — listed for completeness)
+
+- `GET /api/mobile/open/form-settings`
+- `GET /api/mobile/open/order-form/form-settings`
+- `GET /api/mobile/open/order-form/diet-details?cityId={cityId}`
+- `GET /api/mobile/open/order-form/steps/calendar?dietCaloriesId={dietCaloriesId}`
+- `GET /api/mobile/open/order-form/steps/side-orders`
+- `GET /api/mobile/open/settings/form/shopping-cart`
+
+### Dashboard CMS
+
+- `GET /api/open/content-management/interface/DASHBOARD?cId={cityId}` — section
+  layout for the app dashboard.
+- `GET /api/open/content-management/user-stories` — testimonial cards.
+
+Useful only if you want to mirror what the app shows; not needed for the
+diet/price/menu/promo scrape.
 
 ---
 
-## Caveats
+## 7. Observed IDs (Wrocław capture)
 
-- All prices are returned as PLN strings with `" zł"` suffix (e.g. `"62.00 zł"`)
-  on the `constant`/`city` endpoints, but as JSON numbers on
-  `calculate-price`. Strip/parse accordingly.
-- The HAR was captured anonymously; rate limits weren't observable but be
-  polite (sleep between calls; the site is a real business).
-- `top-search` was only seen with `companiesSize=0` in this capture — the
-  documented `companiesSize=N` behaviour is inferred from the response shape
-  (`companies: []` field) and the comparison-engine Redux slice. Verify with a
-  single test call before relying on it.
-- The `_next/data` `buildId` rotates on deploys — don't hard-code it.
+- City: `986283` (Wrocław). Other top-10: `918123` Warszawa, `933016` Gdańsk,
+  `950463` Kraków, `957650` Łódź, `964465` Olsztyn, `969400` Poznań,
+  `977976` Szczecin, `922410` Białystok, `934100` Gdynia.
+- Companies: `robinfood`, `mangodiet` (full HAR coverage). 152 companies are
+  available in Wrocław per `awarded-and-top`.
+- robinfood diets: `4` (Wybór menu, menu-config) + `9, 7, 10, 8, 12, 11, 13`
+  (fixed). 6 tiers under dietId=4: `5, 6, 7, 8, 10, 11`. `dietCaloriesId`
+  range 65–146 + 184/187 (2200 kcal additions).
+- Active promo codes seen: `MG30` (mangodiet, -30%, deadline 2026-05-03,
+  separate=true), `ROBIM30` (robinfood, -30%, deadline 2026-04-26),
+  `MASZWIĘCEJ` (simplebox, -33%, deadline 2026-05-15), `WIOSNA` (twojemenu,
+  -25%, deadline 2026-04-27).
+
+---
+
+## 8. Failures / gotchas
+
+- `GET /api/profile/coupons-search` → 401. Do not depend on it.
+- Prices in `/city/{cityId}` and `companyDiets[].dietTiers[].minPrice` are
+  formatted strings (`"67.00 zł"`). The `/calculate-price` responses use
+  numeric floats. Don't compare them without parsing.
+- `dietPriceInCompanyPromotion: true` in `/city` does **not** mean the promo
+  is auto-applied to anonymous quotes. Some promos (`separate: true`, like
+  `MG30`) require passing the code via `promoCodes`.
+- `menuDaysAhead` is per-company. Quering past `today + menuDaysAhead` on the
+  menu endpoint returns 404 / empty.
+- Some companies have `companyHeader.activePromotionInfo` all-null even when
+  `awarded-and-top` lists a promo for them — refresh from both sources.
+- The `awarded-and-top` `searchData[].name` is the slug, **`fullName`** is the
+  display name; don't confuse them.
+- The mobile menu endpoint is slow (~400 ms). With `menuDaysAhead=18` and ~7
+  kcal levels per fixed diet, a full menu sweep is hundreds of requests per
+  company. Be selective about which leaves you fetch (e.g. one canonical kcal
+  level per diet for daily snapshots).
+
+---
+
+## 9. Scraping playbook
+
+1. **City** → `top-search?query=...` → `cityId`.
+2. **Companies** → `awarded-and-top?cId={cityId}&rV=V2023_1&pageSize=50&page=0..N`
+   until `currentPage == totalPages-1`. Already gives you ratings, params,
+   `priceCategory`, and `activePromotionInfo` for every company in town.
+3. **Per company catalog** → `company-card/{companyId}/constant?cityId={cityId}`
+   for the diet/tier/option/kcal tree, plus `company-card/{companyId}/city/{cityId}`
+   for advertised prices.
+4. **True prices** → for every leaf `dietCaloriesId` (with `tierDietOptionId`
+   for menu-config diets): `POST quick-order/calculate-price` with
+   `deliveryDates=[today+1, ...]`. Use a fixed length (e.g. 10 weekdays) so
+   discounts are comparable across companies.
+5. **Daily menus** → for the `dietCaloriesId` levels you care about:
+   `menu/{dietCaloriesId}/city/{cityId}/date/{YYYY-MM-DD}` for each day in
+   `[today, today+menuDaysAhead]`. Persist by `(date, dietCaloriesId, dietCaloriesMealId)`.
+6. **Promo codes** → union of `companyHeader.activePromotionInfo`,
+   `awarded-and-top.searchData[].activePromotionInfo`, banners
+   (`/api/open/mobile/banners?cId=`), and `recommended-diets`. Validate by
+   round-tripping through `quick-order/calculate-price`.

--- a/scrape.py
+++ b/scrape.py
@@ -1,13 +1,59 @@
-"""Collect diet/price catalog from dietly.pl for a given city.
+"""Scrape diets / prices / menus / promotions from dietly.pl (mobile API).
 
-Usage:
-    python scrape.py "Wrocław" --days 10 --out wroclaw.json
+Usage examples:
+    python scrape.py "Wrocław" --out wroclaw.json
+    python scrape.py "Warszawa" --order-days 10 --menu-days 14 --out warszawa.json
+    python scrape.py "Wrocław" --companies robinfood mangodiet --out wroclaw_sample.json
 
-The script:
-  1. resolves the city via /api/open/search/top-search
-  2. discovers companies (top-search with companiesSize=200)
-  3. for each company, fetches /constant and /city endpoints
-  4. quotes /calculate-price for every (diet, tier, option, kcal) leaf
+Snapshot shape (one JSON file):
+    {
+      "snapshotDate": "2026-04-26",
+      "city": { "cityId": ..., "name": "..." },
+      "companies": [
+        {
+          "companyId": "...",
+          "fullName": "...", "rate": ..., "priceCategory": "...",
+          "activePromotionInfo": { ... },        # from awarded-and-top
+          "constant": { ... },                   # /constant response (full)
+          "cityCard": { ... },                   # /city/{cityId} response
+          "leaves": [                            # one entry per (diet, [tier], option, kcal)
+            {
+              "dietId": ..., "dietName": "...", "dietTag": "...", "isMenuConfiguration": true,
+              "tierId": ..., "tierName": "...", "tierMealsNumber": ...,
+              "dietOptionId": ..., "dietOptionName": "...", "dietOptionTag": "...",
+              "tierDietOptionId": "6-15",
+              "dietCaloriesId": 65, "calories": 1200,
+              "advertised": { "discountPrice": "62.00 zł", "defaultPrice": "62.00 zł", "inPromotion": false },
+              "quote": {                          # from /quick-order/calculate-price
+                "deliveryDates": [...],
+                "totalCostToPay": 670.00,
+                "totalCostWithoutDiscounts": 670.00,
+                "totalLowest30DaysCostWithoutDiscounts": null,
+                "totalPromoCodeDiscount": 0.00,
+                "totalOrderLengthDiscount": 0.00,
+                "perDayWithDiscounts": 67.00,
+                "promoCodes": [],
+                "error": null
+              }
+            }
+          ],
+          "menus": [                              # only fetched for menu-config diets by default
+            {
+              "dietCaloriesId": 65, "tierId": 6, "calories": 1200,
+              "days": [ { "date": "2026-04-26", "meals": [...] }, ... ]
+            }
+          ]
+        }
+      ],
+      "promotions": {
+        "byCompany": [ { "companyId": "...", "code": "...", "discountPercents": 30, "deadline": "...", "source": "constant|awarded-and-top|recommended-diets" } ],
+        "banners": [ ... ],                       # raw /api/open/mobile/banners
+        "recommendedDiets": [ ... ]               # raw /api/open/content-management/recommended-diets
+      }
+    }
+
+To track menus over time, run this on a schedule and diff snapshots by
+(companyId, date, dietCaloriesId, dietCaloriesMealId).
 """
 
 from __future__ import annotations
@@ -17,254 +63,584 @@ import datetime as dt
 import json
 import sys
 import time
-import urllib.parse
-from typing import Iterator
+from typing import Any
 
 import requests
 
-BASE = "https://dietly.pl"
+BASE = "https://aplikacja.dietly.pl"
 HEADERS = {
+    "content-type": "application/json",
     "accept": "application/json",
-    "accept-language": "pl,en;q=0.9",
-    "user-agent": "Mozilla/5.0 (compatible; dietlownik/0.1; +personal-research)",
+    "accept-language": "pl-PL",
+    "x-launcher-type": "ANDROID_APP",
+    "x-mobile-version": "4.0.0",
+    "user-agent": "okhttp/4.9.2",
 }
 
 
-def get(session: requests.Session, path: str, **params) -> dict:
-    r = session.get(BASE + path, params=params or None, headers=HEADERS, timeout=20)
-    r.raise_for_status()
-    return r.json()
+class DietlyClient:
+    def __init__(self, throttle_s: float = 0.4, timeout_s: float = 25.0):
+        self.session = requests.Session()
+        self.session.headers.update(HEADERS)
+        self.throttle_s = throttle_s
+        self.timeout_s = timeout_s
+
+    def _sleep(self) -> None:
+        if self.throttle_s > 0:
+            time.sleep(self.throttle_s)
+
+    def get(self, path: str, *, company_id: str | None = None, **params: Any) -> Any:
+        params = {k: v for k, v in params.items() if v is not None}
+        headers = {"company-id": company_id} if company_id else {}
+        r = self.session.get(
+            BASE + path, params=params or None, headers=headers, timeout=self.timeout_s
+        )
+        self._sleep()
+        r.raise_for_status()
+        return r.json()
+
+    def post(self, path: str, body: dict, company_id: str | None = None) -> Any:
+        headers = {"company-id": company_id} if company_id else {}
+        r = self.session.post(BASE + path, json=body, headers=headers, timeout=self.timeout_s)
+        self._sleep()
+        r.raise_for_status()
+        return r.json()
+
+    # ---- discovery ----
+
+    def resolve_city(self, name: str) -> dict:
+        data = self.get(
+            "/api/open/search/top-search",
+            query=name,
+            citiesSize=10,
+            companiesSize=0,
+        )
+        for city in data.get("cities") or []:
+            if city["name"].lower() == name.lower() or city["sanitizedName"] == name.lower():
+                return city
+        if data.get("cities"):
+            return data["cities"][0]
+        raise SystemExit(f"No city matched {name!r}")
+
+    def list_companies(self, city_id: int, page_size: int = 50) -> list[dict]:
+        out: list[dict] = []
+        page = 0
+        while True:
+            data = self.get(
+                "/api/open/search/full/awarded-and-top",
+                cId=city_id,
+                rV="V2023_1",
+                pageSize=page_size,
+                page=page,
+                active="",
+            )
+            out.extend(data.get("searchData") or [])
+            total_pages = data.get("totalPages") or 1
+            page += 1
+            if page >= total_pages:
+                break
+        return out
+
+    # ---- per-company ----
+
+    def company_constant(self, company_id: str, city_id: int) -> dict:
+        return self.get(
+            f"/api/mobile/open/company-card/{company_id}/constant",
+            company_id=company_id,
+            cityId=city_id,
+        )
+
+    def company_city_card(self, company_id: str, city_id: int) -> dict:
+        return self.get(
+            f"/api/mobile/open/company-card/{company_id}/city/{city_id}",
+            company_id=company_id,
+        )
+
+    def quick_order_price(
+        self,
+        company_id: str,
+        city_id: int,
+        diet_calories_id: int,
+        delivery_dates: list[str],
+        tier_diet_option_id: str | None = None,
+        promo_codes: list[str] | None = None,
+    ) -> dict:
+        body: dict[str, Any] = {
+            "cityId": city_id,
+            "deliveryDates": list(delivery_dates),
+            "dietCaloriesId": diet_calories_id,
+            "promoCodes": list(promo_codes) if promo_codes else [""],
+            "testOrder": False,
+        }
+        if tier_diet_option_id is not None:
+            body["tierDietOptionId"] = tier_diet_option_id
+        return self.post(
+            f"/api/mobile/open/company-card/{company_id}/quick-order/calculate-price",
+            body,
+            company_id=company_id,
+        )
+
+    def menu(
+        self,
+        company_id: str,
+        diet_calories_id: int,
+        city_id: int,
+        date: str,
+        tier_id: int | None = None,
+    ) -> dict:
+        path = f"/api/mobile/open/company-card/{company_id}/menu/{diet_calories_id}/city/{city_id}/date/{date}"
+        return self.get(path, company_id=company_id, tierId=tier_id)
+
+    # ---- promotion feeds ----
+
+    def banners(self, city_id: int) -> list[dict]:
+        return self.get("/api/open/mobile/banners", cId=city_id)
+
+    def recommended_diets(self, city_id: int, page_size: int = 20) -> list[dict]:
+        return self.get(
+            "/api/open/content-management/recommended-diets",
+            cId=city_id,
+            page=0,
+            pageSize=page_size,
+        )
 
 
-def post(session: requests.Session, path: str, body: dict) -> dict:
-    r = session.post(BASE + path, json=body, headers=HEADERS, timeout=20)
-    r.raise_for_status()
-    return r.json()
+# ---- catalog walking ----
+
+def iter_leaves(constant: dict):
+    """Yield (diet, tier|None, option, kcal) for every leaf in /constant."""
+    for diet in constant.get("companyDiets") or []:
+        if diet.get("isMenuConfiguration") and diet.get("dietTiers"):
+            for tier in diet["dietTiers"]:
+                for option in tier.get("dietOptions") or []:
+                    for kcal in option.get("dietCalories") or []:
+                        yield diet, tier, option, kcal
+        else:
+            for option in diet.get("dietOptions") or []:
+                for kcal in option.get("dietCalories") or []:
+                    yield diet, None, option, kcal
 
 
-def resolve_city(session, name: str) -> dict:
-    data = get(
-        session,
-        "/api/open/search/top-search",
-        query=name,
-        citiesSize=10,
-        companiesSize=0,
-    )
-    cities = [c for c in data["cities"] if c.get("cityStatus")]
-    if not cities:
-        raise SystemExit(f"no supported city matched {name!r}")
-    cities.sort(key=lambda c: -c["numberOfCompanies"])
-    return cities[0]
+# ---- date helpers ----
+
+def weekday_dates(start: dt.date, count: int, include_weekends: bool = True) -> list[str]:
+    """Return `count` consecutive future calendar dates starting at `start`."""
+    out: list[str] = []
+    d = start
+    while len(out) < count:
+        if include_weekends or d.weekday() < 5:
+            out.append(d.isoformat())
+        d += dt.timedelta(days=1)
+    return out
 
 
-def list_companies(session, city_name: str) -> list[dict]:
-    """Fetches companies via top-search. Inferred from response shape — verify
-    with a small companiesSize first run if you're being cautious."""
-    data = get(
-        session,
-        "/api/open/search/top-search",
-        query=city_name,
-        citiesSize=0,
-        companiesSize=200,
-    )
-    return data.get("companies") or []
+# ---- quote / menu collectors ----
 
-
-def company_constant(session, company_id: str, city_id: int) -> dict:
-    return get(
-        session,
-        f"/api/dietly/open/company-card/{company_id}/constant",
-        cityId=city_id,
-    )
-
-
-def company_city_summary(session, company_id: str, city_id: int) -> dict:
-    return get(
-        session,
-        f"/api/dietly/open/company-card/{company_id}/city/{city_id}",
-    )
-
-
-def calc_price(
-    session,
+def collect_leaves(
+    client: DietlyClient,
     company_id: str,
-    *,
     city_id: int,
-    diet_calories_id: int,
+    constant: dict,
+    city_card: dict,
     delivery_dates: list[str],
-    tier_diet_option_id: str | None = None,
-    promo_codes: list[str] | None = None,
-) -> dict:
-    body = {
-        "promoCodes": promo_codes or [],
-        "deliveryDates": delivery_dates,
-        "dietCaloriesId": diet_calories_id,
-        "testOrder": False,
-        "cityId": city_id,
-    }
-    if tier_diet_option_id:
-        body["tierDietOptionId"] = tier_diet_option_id
-    return post(
-        session,
-        f"/api/dietly/open/company-card/{company_id}/quick-order/calculate-price",
-        body,
-    )
-
-
-def consecutive_dates(n: int, start: dt.date | None = None) -> list[str]:
-    """N consecutive calendar days starting tomorrow by default. The price API
-    accepts non-business days as long as the company delivers on them — but if
-    you want strict business days, filter here against deliveryOnSaturday /
-    deliveryOnSunday from companyParams."""
-    start = start or (dt.date.today() + dt.timedelta(days=1))
-    return [(start + dt.timedelta(days=i)).isoformat() for i in range(n)]
-
-
-def iter_leaves(constant: dict) -> Iterator[dict]:
-    """Yield every quotable leaf — one per (diet, tier, option, kcal). For
-    ready (non-tiered) diets, falls back to (dietId, kcal) only — but in this
-    HAR every diet had tiers populated through the constant endpoint, so the
-    common case is fully qualified."""
-    for diet in constant.get("companyDiets", []):
-        diet_id = diet["dietId"]
-        diet_name = diet["name"]
-        diet_tag = diet.get("dietTag")
-        is_menu = diet.get("isMenuConfiguration", False)
-        tiers = diet.get("dietTiers") or []
-        if not tiers:
-            yield {
-                "dietId": diet_id,
-                "dietName": diet_name,
-                "dietTag": diet_tag,
-                "isMenuConfiguration": is_menu,
-                "tierId": None,
-                "tierName": None,
-                "tierDietOptionId": None,
-                "dietOptionId": None,
-                "dietOptionName": None,
-                "dietCaloriesId": None,
-                "calories": None,
+    promo_codes: list[str] | None,
+) -> list[dict]:
+    advertised_by_id: dict[int, dict] = {}
+    for entry in city_card.get("dietPriceInfo") or []:
+        for cid in entry.get("dietCaloriesIds") or []:
+            advertised_by_id[cid] = {
+                "discountPrice": entry.get("discountPrice"),
+                "defaultPrice": entry.get("defaultPrice"),
+                "inPromotion": entry.get("dietPriceInCompanyPromotion"),
             }
-            continue
-        for tier in tiers:
-            for option in tier.get("dietOptions", []):
-                for cal in option.get("dietCalories", []):
-                    yield {
-                        "dietId": diet_id,
-                        "dietName": diet_name,
-                        "dietTag": diet_tag,
-                        "isMenuConfiguration": is_menu,
-                        "tierId": tier["tierId"],
-                        "tierName": tier["name"],
-                        "tierDietOptionId": option["tierDietOptionId"],
-                        "dietOptionId": option["dietOptionId"],
-                        "dietOptionName": option["name"],
-                        "dietCaloriesId": cal["dietCaloriesId"],
-                        "calories": cal["calories"],
-                    }
 
-
-def quote_company(
-    session,
-    company: dict,
-    city_id: int,
-    days: int,
-    promo_codes: list[str],
-    sleep: float,
-) -> dict:
-    company_id = company["companyId"] if "companyId" in company else company["sanitizedName"]
-    constant = company_constant(session, company_id, city_id)
-    summary = company_city_summary(session, company_id, city_id)
-    dates = consecutive_dates(days)
-    quotes = []
-    for leaf in iter_leaves(constant):
-        if leaf["dietCaloriesId"] is None:
-            continue
+    leaves: list[dict] = []
+    for diet, tier, option, kcal in iter_leaves(constant):
+        diet_calories_id = kcal["dietCaloriesId"]
+        tier_diet_option_id = (
+            f"{tier['tierId']}-{option['dietOptionId']}" if tier else None
+        )
+        leaf = {
+            "dietId": diet["dietId"],
+            "dietName": diet["name"],
+            "dietTag": diet.get("dietTag"),
+            "isMenuConfiguration": diet.get("isMenuConfiguration", False),
+            "tierId": tier["tierId"] if tier else None,
+            "tierName": tier["name"] if tier else None,
+            "tierMealsNumber": tier.get("mealsNumber") if tier else None,
+            "dietOptionId": option["dietOptionId"],
+            "dietOptionName": option["name"],
+            "dietOptionTag": option.get("dietOptionTag"),
+            "tierDietOptionId": tier_diet_option_id,
+            "dietCaloriesId": diet_calories_id,
+            "calories": kcal["calories"],
+            "advertised": advertised_by_id.get(diet_calories_id),
+        }
         try:
-            price = calc_price(
-                session,
-                company_id,
+            quote = client.quick_order_price(
+                company_id=company_id,
                 city_id=city_id,
-                diet_calories_id=leaf["dietCaloriesId"],
-                delivery_dates=dates,
-                tier_diet_option_id=leaf["tierDietOptionId"] if leaf["isMenuConfiguration"] else None,
+                diet_calories_id=diet_calories_id,
+                delivery_dates=delivery_dates,
+                tier_diet_option_id=tier_diet_option_id,
                 promo_codes=promo_codes,
             )
-        except requests.HTTPError as e:
-            print(f"  ! {company_id} {leaf['dietName']} {leaf['calories']}kcal: {e}", file=sys.stderr)
-            continue
-        item = price["items"][0] if price.get("items") else {}
-        quotes.append(
-            {
-                **leaf,
-                "perDay": item.get("perDayDietCost"),
-                "perDayWithDiscount": item.get("perDayDietWithDiscountsCost"),
-                "total": price["cart"]["totalCostToPay"],
-                "totalWithoutDiscount": price["cart"]["totalCostWithoutDiscounts"],
-                "deliveryCost": price["cart"]["totalDeliveryCost"],
+            cart = quote.get("cart", {})
+            items = quote.get("items") or [{}]
+            leaf["quote"] = {
+                "deliveryDates": delivery_dates,
+                "totalCostToPay": cart.get("totalCostToPay"),
+                "totalCostWithoutDiscounts": cart.get("totalCostWithoutDiscounts"),
+                "totalLowest30DaysCostWithoutDiscounts": cart.get(
+                    "totalLowest30DaysCostWithoutDiscounts"
+                ),
+                "totalPromoCodeDiscount": cart.get("totalPromoCodeDiscount"),
+                "totalOrderLengthDiscount": cart.get("totalOrderLengthDiscount"),
+                "totalDeliveryCost": cart.get("totalDeliveryCost"),
+                "perDayWithDiscounts": items[0].get("perDayDietWithDiscountsCost"),
+                "perDay": items[0].get("perDayDietCost"),
+                "promoCodes": list(promo_codes or []),
+                "error": None,
             }
-        )
-        time.sleep(sleep)
+        except requests.HTTPError as e:
+            leaf["quote"] = {
+                "deliveryDates": delivery_dates,
+                "error": f"HTTP {e.response.status_code}",
+                "promoCodes": list(promo_codes or []),
+            }
+        leaves.append(leaf)
+    return leaves
+
+
+def collect_menus(
+    client: DietlyClient,
+    company_id: str,
+    city_id: int,
+    constant: dict,
+    menu_days: int,
+    start_date: dt.date,
+    only_menu_config: bool,
+) -> list[dict]:
+    """Fetch menus for one canonical kcal level per (diet, tier, option).
+
+    Different kcal levels under the same option serve the same dishes with
+    different portion sizes, so fetching the lowest kcal is enough to track
+    which dishes appear on which day.
+    """
+    days_ahead = constant.get("menuSettings", {}).get("menuDaysAhead") or 0
+    if not constant.get("menuSettings", {}).get("menuEnabled") or not days_ahead:
+        return []
+    days_to_fetch = min(menu_days, days_ahead)
+    dates = weekday_dates(start_date, days_to_fetch)
+
+    targets: list[dict] = []
+    seen: set[tuple[int | None, int]] = set()
+    for diet, tier, option, kcal in iter_leaves(constant):
+        if only_menu_config and not diet.get("isMenuConfiguration"):
+            continue
+        key = (tier["tierId"] if tier else None, option["dietOptionId"])
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append({
+            "dietId": diet["dietId"],
+            "dietName": diet["name"],
+            "tierId": tier["tierId"] if tier else None,
+            "tierName": tier["name"] if tier else None,
+            "dietOptionId": option["dietOptionId"],
+            "dietOptionName": option["name"],
+            "dietCaloriesId": kcal["dietCaloriesId"],
+            "calories": kcal["calories"],
+        })
+
+    out: list[dict] = []
+    for t in targets:
+        days = []
+        for date in dates:
+            try:
+                payload = client.menu(
+                    company_id, t["dietCaloriesId"], city_id, date, tier_id=t["tierId"]
+                )
+                days.append(_compact_menu_day(payload))
+            except requests.HTTPError as e:
+                days.append({"date": date, "error": f"HTTP {e.response.status_code}"})
+        out.append({**t, "days": days})
+    return out
+
+
+def _compact_menu_day(payload: dict) -> dict:
+    """Flatten the menu response to keep snapshots diff-friendly."""
+    meals = []
+    for meal in payload.get("meals") or []:
+        options = []
+        for opt in meal.get("options") or []:
+            details = opt.get("details") or {}
+            options.append({
+                "dietCaloriesMealId": opt.get("dietCaloriesMealId"),
+                "name": opt.get("name"),
+                "label": opt.get("label"),
+                "info": opt.get("info"),
+                "thermo": opt.get("thermo"),
+                "reviewsScore": opt.get("reviewsScore"),
+                "reviewsNumber": opt.get("reviewsNumber"),
+                "imageUrl": details.get("imageUrl"),
+                "macros": {
+                    "calories": details.get("calories"),
+                    "protein": details.get("protein"),
+                    "carbohydrate": details.get("carbohydrate"),
+                    "fat": details.get("fat"),
+                    "fiber": details.get("dietaryFiber"),
+                    "sugar": details.get("sugar"),
+                    "saturatedFat": details.get("saturatedFattyAcids"),
+                    "salt": details.get("salt"),
+                },
+                "allergens": [
+                    a.get("dietlyAllergenName")
+                    for a in (details.get("allergensWithExcluded") or [])
+                ],
+                "ingredients": [i.get("name") for i in (details.get("ingredients") or [])],
+            })
+        meals.append({
+            "name": meal.get("name"),
+            "baseDietCaloriesMealId": meal.get("baseDietCaloriesMealId"),
+            "options": options,
+        })
+    return {"date": payload.get("date"), "calories": payload.get("calories"), "meals": meals}
+
+
+# ---- promotion aggregator ----
+
+def gather_promotions(
+    companies_summary: list[dict],
+    company_results: list[dict],
+    banners: list[dict],
+    recommended: list[dict],
+) -> dict:
+    by_company: dict[tuple[str, str], dict] = {}
+
+    def add(source: str, company_id: str | None, info: dict | None):
+        if not company_id or not info:
+            return
+        code = info.get("code")
+        if not code:
+            return
+        key = (company_id, code)
+        existing = by_company.get(key)
+        record = {
+            "companyId": company_id,
+            "code": code,
+            "discountPercents": info.get("discountPercents"),
+            "deadline": info.get("promoDeadline"),
+            "promoText": info.get("promoText"),
+            "separate": info.get("separate"),
+            "sources": [source],
+        }
+        if existing:
+            existing["sources"] = sorted(set(existing["sources"] + [source]))
+        else:
+            by_company[key] = record
+
+    for c in companies_summary:
+        add("awarded-and-top", c.get("name"), c.get("activePromotionInfo"))
+
+    for c in company_results:
+        cid = c.get("companyId")
+        header = (c.get("constant") or {}).get("companyHeader") or {}
+        add("constant", cid, header.get("activePromotionInfo"))
+
+    for r in recommended or []:
+        cid = (r.get("companyData") or {}).get("companyId")
+        add("recommended-diets", cid, r.get("activePromotion"))
+
     return {
-        "companyId": company_id,
-        "companyName": constant.get("companyHeader", {}).get("name"),
-        "rate": constant.get("companyHeader", {}).get("rate"),
-        "feedbackNumber": constant.get("companyHeader", {}).get("feedbackNumber"),
-        "lowestPrice": summary.get("lowestPrice"),
-        "companyPriceCategory": summary.get("companyPriceCategory"),
-        "deliveryOnSaturday": constant.get("companyParams", {}).get("deliveryOnSaturday"),
-        "deliveryOnSunday": constant.get("companyParams", {}).get("deliveryOnSunday"),
-        "quotes": quotes,
+        "byCompany": list(by_company.values()),
+        "banners": banners,
+        "recommendedDiets": recommended,
     }
 
 
-def main() -> None:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("city", help='city name, e.g. "Wrocław"')
-    ap.add_argument("--days", type=int, default=10)
-    ap.add_argument("--promo", action="append", default=[])
-    ap.add_argument("--out", default="-")
-    ap.add_argument("--sleep", type=float, default=0.3)
-    ap.add_argument("--limit", type=int, default=None, help="cap company count for testing")
-    ap.add_argument(
+# ---- main ----
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scrape dietly.pl for a city.")
+    parser.add_argument("city", help="City name, e.g. 'Wrocław'")
+    parser.add_argument("--out", required=True, help="Output JSON path")
+    parser.add_argument(
+        "--order-days",
+        type=int,
+        default=10,
+        help="How many delivery days to use for the price quote (default 10).",
+    )
+    parser.add_argument(
+        "--menu-days",
+        type=int,
+        default=7,
+        help="How many days of menu to fetch per kcal target (default 7).",
+    )
+    parser.add_argument(
         "--companies",
         nargs="*",
-        default=None,
-        help="explicit companyId list (skips discovery)",
+        help="Limit to a specific list of companyId slugs (default: all in city).",
     )
-    args = ap.parse_args()
+    parser.add_argument(
+        "--no-menus",
+        action="store_true",
+        help="Skip menu fetching (fast catalog/price snapshot only).",
+    )
+    parser.add_argument(
+        "--menus-all-diets",
+        action="store_true",
+        help="Fetch menus for fixed (non-menu-config) diets too. Default is menu-config only.",
+    )
+    parser.add_argument(
+        "--throttle",
+        type=float,
+        default=0.35,
+        help="Sleep seconds between requests (default 0.35).",
+    )
+    parser.add_argument(
+        "--promo-code",
+        action="append",
+        default=[],
+        help="Promo code to attach to all price quotes (repeatable).",
+    )
+    args = parser.parse_args(argv)
 
-    session = requests.Session()
+    client = DietlyClient(throttle_s=args.throttle)
 
-    city = resolve_city(session, args.city)
-    print(f"city: {city['name']} (cityId={city['cityId']}, {city['numberOfCompanies']} companies)", file=sys.stderr)
+    today = dt.date.today()
+    delivery_dates = weekday_dates(today + dt.timedelta(days=2), args.order_days)
+
+    print(f"Resolving city: {args.city}", file=sys.stderr)
+    city = client.resolve_city(args.city)
+    city_id = city["cityId"]
+    print(f"  -> cityId={city_id} ({city['name']})", file=sys.stderr)
+
+    print("Listing companies in city…", file=sys.stderr)
+    companies_summary = client.list_companies(city_id)
+    print(f"  -> {len(companies_summary)} companies", file=sys.stderr)
 
     if args.companies:
-        companies = [{"companyId": cid, "sanitizedName": cid} for cid in args.companies]
-    else:
-        companies = list_companies(session, city["name"])
-        print(f"discovered {len(companies)} companies", file=sys.stderr)
+        wanted = set(args.companies)
+        companies_summary = [c for c in companies_summary if c.get("name") in wanted]
+        print(f"  filtered to {len(companies_summary)}", file=sys.stderr)
 
-    if args.limit:
-        companies = companies[: args.limit]
+    print("Fetching banners + recommended diets…", file=sys.stderr)
+    try:
+        banners = client.banners(city_id)
+    except requests.HTTPError as e:
+        print(f"  banners failed: {e}", file=sys.stderr)
+        banners = []
+    try:
+        recommended = client.recommended_diets(city_id)
+    except requests.HTTPError as e:
+        print(f"  recommended-diets failed: {e}", file=sys.stderr)
+        recommended = []
 
-    out = []
-    for i, c in enumerate(companies, 1):
-        cid = c.get("companyId") or c.get("sanitizedName")
-        print(f"[{i}/{len(companies)}] {cid}", file=sys.stderr)
+    company_results: list[dict] = []
+    for i, summary in enumerate(companies_summary, 1):
+        cid = summary.get("name")
+        if not cid:
+            continue
+        print(f"[{i}/{len(companies_summary)}] {cid}", file=sys.stderr)
         try:
-            out.append(quote_company(session, c, city["cityId"], args.days, args.promo, args.sleep))
+            constant = client.company_constant(cid, city_id)
+            city_card = client.company_city_card(cid, city_id)
         except requests.HTTPError as e:
-            print(f"  ! {cid}: {e}", file=sys.stderr)
+            print(f"  catalog fetch failed: {e}", file=sys.stderr)
+            continue
 
-    payload = {"city": city, "days": args.days, "promoCodes": args.promo, "companies": out}
-    if args.out == "-":
-        json.dump(payload, sys.stdout, indent=2, ensure_ascii=False)
-    else:
-        with open(args.out, "w", encoding="utf-8") as f:
-            json.dump(payload, f, indent=2, ensure_ascii=False)
-        print(f"wrote {args.out}", file=sys.stderr)
+        leaves = collect_leaves(
+            client=client,
+            company_id=cid,
+            city_id=city_id,
+            constant=constant,
+            city_card=city_card,
+            delivery_dates=delivery_dates,
+            promo_codes=args.promo_code or None,
+        )
+
+        menus: list[dict] = []
+        if not args.no_menus:
+            menus = collect_menus(
+                client=client,
+                company_id=cid,
+                city_id=city_id,
+                constant=constant,
+                menu_days=args.menu_days,
+                start_date=today,
+                only_menu_config=not args.menus_all_diets,
+            )
+
+        company_results.append({
+            "companyId": cid,
+            "fullName": summary.get("fullName"),
+            "rate": summary.get("rate"),
+            "numberOfRates": summary.get("numberOfRates"),
+            "priceCategory": summary.get("priceCategory"),
+            "awarded": summary.get("awarded"),
+            "params": summary.get("params"),
+            "activePromotionInfo": summary.get("activePromotionInfo"),
+            "constant": constant,
+            "cityCard": city_card,
+            "leaves": leaves,
+            "menus": menus,
+        })
+
+    promotions = gather_promotions(companies_summary, company_results, banners, recommended)
+
+    snapshot = {
+        "snapshotDate": today.isoformat(),
+        "snapshotTimestamp": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "city": {"cityId": city_id, "name": city["name"], "raw": city},
+        "queryParams": {
+            "orderDays": args.order_days,
+            "menuDays": args.menu_days,
+            "deliveryDates": delivery_dates,
+            "promoCodes": list(args.promo_code or []),
+            "menusAllDiets": args.menus_all_diets,
+            "noMenus": args.no_menus,
+        },
+        "companies": company_results,
+        "promotions": promotions,
+    }
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {args.out}", file=sys.stderr)
+
+    n_days = max(len(delivery_dates), 1)
+    cheapest = sorted(
+        (
+            {
+                "companyId": c["companyId"],
+                "perDay": (leaf["quote"]["totalCostToPay"] / n_days),
+                "diet": leaf["dietName"],
+                "tier": leaf["tierName"],
+                "option": leaf["dietOptionName"],
+                "kcal": leaf["calories"],
+            }
+            for c in company_results
+            for leaf in c["leaves"]
+            if (leaf.get("quote") or {}).get("totalCostToPay") is not None
+        ),
+        key=lambda r: r["perDay"],
+    )[:5]
+    if cheapest:
+        promo = ", ".join(args.promo_code) if args.promo_code else "no promo"
+        print(
+            f"Cheapest 5 (per-day @ {n_days}-day order, {promo}):",
+            file=sys.stderr,
+        )
+        for row in cheapest:
+            print(
+                f"  {row['perDay']:>7.2f} zł  {row['companyId']:<20} "
+                f"{row['diet']} / {row['tier'] or '-'} / {row['option']} @ {row['kcal']} kcal",
+                file=sys.stderr,
+            )
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Rewrites `API.md` and `scrape.py` against the **mobile** API at `aplikacja.dietly.pl` (the previous version targeted the website at `dietly.pl`). The mobile capture exposes richer per-meal data (macros, allergens, ingredients, image URLs), a working `awarded-and-top` catalog endpoint that lists every company in a city (152 for Wrocław, paginated), and `quick-order/calculate-price`, which accepts public promo codes for anonymous quotes — verified end-to-end with `MG30` (88.00 → 61.60 zł on mango.diet).
- Documents 4 ways to discover promo codes since `/api/profile/coupons-search` requires login (401 anonymously): `companyHeader.activePromotionInfo`, `awarded-and-top.searchData[].activePromotionInfo`, `/api/open/mobile/banners`, and `/api/open/content-management/recommended-diets`. Captured codes can be validated by round-tripping through `quick-order/calculate-price`.
- Notable correction vs. the old web docs: the `company-id` request header is **required** on `/api/mobile/open/company-card/{companyId}/...` calls (live API returns 400 without it, despite the slug being in the URL).
- `scrape.py` produces one diff-friendly JSON snapshot covering: full company catalog, true per-day prices for every (diet, tier, option, kcal) leaf, daily menus deduped to one canonical kcal per (tier, option), and aggregated promotions with source provenance. Flags: `--companies`, `--order-days`, `--menu-days`, `--no-menus`, `--menus-all-diets`, `--promo-code` (repeatable), `--throttle`.

## Test plan
- [x] `python3 scrape.py "Wrocław" --companies robinfood --no-menus --order-days 3 --out smoke.json` — catalog + price quotes succeed; cheapest is `Standard Food @ 1200 kcal = 57 zł/day`.
- [x] `python3 scrape.py "Wrocław" --companies mangodiet --no-menus --order-days 1 --promo-code MG30 --out promo.json` — `MG30` applied: 88.00 → 61.60 zł, Omnibus reference 85.00 zł captured.
- [x] `python3 scrape.py "Wrocław" --companies robinfood --order-days 3 --menu-days 1 --out menus.json` — 22 menu fetches per day (one per `(tier, option)` combo), each meal-day has 5 meal types × 5 options with full macros + allergens + ingredients.
- [x] Tolerates upstream 5xx on `recommended-diets` (which is currently flaky) without aborting the run.
- [ ] Run a full-city sweep (no `--companies` filter) and confirm 152 companies are walked without rate-limit errors at the default `--throttle 0.35`.
- [ ] Schedule a daily snapshot and verify menu changes are detectable by diffing `(companyId, date, dietCaloriesMealId)` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)