### PR TITLE
feat(deploy): production Dockerfile with Next standalone output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Dependencies and build output (rebuilt inside the image)
+node_modules
+.next
+dist
+
+# VCS and editor
+.git
+.gitignore
+.gitattributes
+.vscode
+.idea
+.DS_Store
+
+# Local env (DATABASE_URL is passed at runtime, never baked in)
+.env
+.env.local
+.env.*.local
+
+# Scraper code, tests, and migrations — not needed for the web image
+scraper
+db
+vitest.config.ts
+scrape.py
+
+# Reverse-engineering artifacts (often contain auth tokens)
+*.har
+
+# Project / agent docs (not needed in production image)
+README.md
+AGENTS.md
+CLAUDE.md
+.impeccable.md
+.claude
+.agents
+skills-lock.json
+
+# TypeScript build cache
+*.tsbuildinfo
+next-env.d.ts
+
+# Logs and coverage
+*.log
+coverage
+
+# Docker artifacts (don't recurse into ourselves)
+Dockerfile
+.dockerignore
+docker-compose*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+
+# ────────────────────────────────────────────────────────────────────────────
+# Stage 1 — install deps with Bun (matches bun.lock)
+# ────────────────────────────────────────────────────────────────────────────
+FROM oven/bun:1.2-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# ────────────────────────────────────────────────────────────────────────────
+# Stage 2 — build the Next.js app (standalone output)
+# ────────────────────────────────────────────────────────────────────────────
+FROM oven/bun:1.2-alpine AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN bun run build
+
+# ────────────────────────────────────────────────────────────────────────────
+# Stage 3 — minimal runtime (Node, non-root, only the standalone bundle)
+# ────────────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nextjs \
+ && adduser --system --uid 1001 --ingroup nextjs nextjs
+
+# Standalone server + traced node_modules.
+COPY --from=builder --chown=nextjs:nextjs /app/.next/standalone ./
+# Static chunks (Next does not include these in standalone).
+COPY --from=builder --chown=nextjs:nextjs /app/.next/static ./.next/static
+# Public assets (favicon, fonts, etc).
+COPY --from=builder --chown=nextjs:nextjs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# DATABASE_URL must be supplied at runtime (e.g. `docker run -e DATABASE_URL=...`).
+CMD ["node", "server.js"]

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,11 +5,11 @@ declare global {
   var __dietlownikPool: Pool | undefined;
 }
 
-function makePool() {
+function makePool(): Pool {
   const url = process.env.DATABASE_URL;
   if (!url) {
     throw new Error(
-      "DATABASE_URL is not set. Expected it in /Users/rei/projects/dietlownik/.env (loaded via next.config.ts)."
+      "DATABASE_URL is not set. Provide it via .env (dev) or environment (prod)."
     );
   }
   return new Pool({
@@ -20,16 +20,20 @@ function makePool() {
   });
 }
 
-export const pool: Pool = global.__dietlownikPool ?? makePool();
-
-if (process.env.NODE_ENV !== "production") {
+// Lazy: pool is created on first call, then cached on globalThis so HMR
+// doesn't leak connections in dev. Module load must NOT throw — Next collects
+// page data at build time without env vars set.
+function getPool(): Pool {
+  if (global.__dietlownikPool) return global.__dietlownikPool;
+  const pool = makePool();
   global.__dietlownikPool = pool;
+  return pool;
 }
 
 export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
   params: unknown[] = []
 ) {
-  const res = await pool.query<T>(text, params as never[]);
+  const res = await getPool().query<T>(text, params as never[]);
   return res.rows;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   serverExternalPackages: ["pg"],
 };
 


### PR DESCRIPTION
Multi-stage build:
- deps: bun install --frozen-lockfile (matches bun.lock)
- builder: bun run build with output: 'standalone' so Next traces only what's used at runtime (pg ends up in .next/standalone/node_modules)
- runner: node:22-alpine, non-root user, ~306 MB image

Side effect: makes the pg pool lazy (created on first query, not at module load) so `next build` route-data collection doesn't crash when DATABASE_URL is absent — required for any CI/Docker build that doesn't ship credentials in the image.

DATABASE_URL is supplied at runtime (-e). Verified end-to-end: container serves real data on / and /api/price-history.