### PR TITLE
prices: add 1-day order tier as no-discount baseline

### DIFF
--- a/scraper/scrapers/prices.ts
+++ b/scraper/scrapers/prices.ts
@@ -2,7 +2,9 @@ import { post, futureWeekdays } from '../api.js';
 import { q } from '../db.js';
 import type { PriceRequestBody, PriceResponse, PriceLeaf } from '../types.js';
 
-const ORDER_DAY_TIERS = [5, 10, 20];
+// 1 = no order-length discount (true list price, comparable to /city
+//     dietPriceInfo). 5 / 10 / 20 are the dashboard-visible plan lengths.
+const ORDER_DAY_TIERS = [1, 5, 10, 20];
 const CONCURRENCY = 8;
 
 async function getLeaves(companyId: string): Promise<PriceLeaf[]> {


### PR DESCRIPTION
## Summary
- Adds a 1-day quote alongside the existing 5/10/20-day tiers. Captures the truthful list price with no order-length discount applied — comparable to `dietPriceInfo.discountPrice` / `defaultPrice` in `/city`, but produced by the same `quick-order/calculate-price` oracle as the other tiers (so it stays apples-to-apples).
- Verified against the live API: robinfood Wrocław Fit 1200 kcal under tier 6-17 → 67.00 zł on day 1 with `totalOrderLengthDiscount=0`; same per-day rate at 5 days yields 318.25 (16.75 discount = 5%); 10 days drops to 603 (67 discount = 10%); 20 days plateaus at the same 10% cap.

## Test plan
- [x] Smoke: `COMPANY=robinfood SKIP_MENUS=1 SKIP_PROMOS=1 npm run scrape` → 804 rows = 201 leaves × 4 tiers.
- [x] Sanity-checked `total_order_length_discount` is 0 for `order_days=1` and grows monotonically with the longer tiers.
- [ ] Time-series queries that filter by `order_days` should treat `1` as "from this point forward" — older snapshots predate the column value.

## Notes
- Targets `main`. Stacks naturally on top of #2 (time-series-scraper) — if #2 merges first, this is a 1-line change against the new mobile API code path; if this merges first, PR #2 will need a trivial conflict resolution on the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)